### PR TITLE
Fixing issue with semicolons not being printed out for TSPropertySignature's

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2293,6 +2293,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       }
 
       parts.push(n.optional ? "?" : "", path.call(print, "typeAnnotation"));
+      parts.push(";");
 
       return concat(parts);
 


### PR DESCRIPTION
Adds a fix to append a  semicolon to the end of a TSPropertySignature statement.

```
export interface Test {
  A: string;
  R: string;
}
```

Without the fix, if I were to add a Typescript property named X with a string annotation it would print out as:

```
export interface Test {
  A: string;
  R: string;
  X: string
}
```